### PR TITLE
Fix file name and path mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sharejs:
   enable: true
   cdn:
     js: //cdn.jsdelivr.net/npm/social-share.js@1/dist/js/social-share.min.js
-    css: //cdn.jsdelivr.net/npm/social-share.js@1/dist/js/social-share.min.css
+    css: //cdn.jsdelivr.net/npm/social-share.js@1/dist/css/share.min.css
   networks: weibo,qq,wechat,tencent,douban,qzone,linkedin,diandian,facebook,twitter,google
   wechat_qrcode:
     title: share.title


### PR DESCRIPTION
With this fix, the css file would load normally. The original path for the css is actually wrong and cause the icons not to load.